### PR TITLE
Disable/style sidebar versions button when there is only one version.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,10 @@ public/
 build/
 .DS_STORE
 .editorconfig
+
+# Webstorm
+.idea
+
+# gh-pages builds
+gh-pages/*
+!gh-pages/index.html

--- a/preview-src/ui-model.yml
+++ b/preview-src/ui-model.yml
@@ -8,37 +8,7 @@ site:
     url: '#'
     versions:
     - &latest_version_abc
-      url: '#' 
-      version: '1.1'
-      displayVersion: '1.1'
-      navigation:
-      - root: true
-        content: Jenkins Templating Engine
-        url: '#'
-        urlType: fragment
-        items:
-        - content: Quickstart 1.1
-          url: '#'
-          urlType: fragment
-          items:
-          - content: Brand&#8217;s Hardware &amp; Software Requirements extra long title
-            url: /xyz/5.2/index.html
-            urlType: internal
-          - content: IDE Integration
-            url: '#'
-            urlType: fragment
-        - content: Liber Recusabo
-          url: '#liber-recusabo'
-          urlType: fragment
-        - content: Reference
-          items:
-          - content: Keyboard Shortcuts
-            url: '#'
-            urlType: fragment
-          - content: Importing and Exporting
-            url: '#'
-            urlType: fragment
-    - url: '#' 
+      url: '#'
       version: '1.0'
       displayVersion: '1.0'
       navigation:

--- a/src/js/00-nav.js
+++ b/src/js/00-nav.js
@@ -35,7 +35,8 @@
 
     // Disable select if there is only one version
     if (s.options.length === 1) {
-      s.disabled = true
+      s.classList.add('single-version');
+      s.disabled = true;
     }
   }
 

--- a/src/js/00-nav.js
+++ b/src/js/00-nav.js
@@ -32,14 +32,18 @@
       navShow.classList.remove('hide')
       navHide.classList.add('hide')
     })
+
+    // Disable select if there is only one version
+    if (s.options.length === 1) {
+      s.disabled = true
+    }
   }
 
   /// nav-tree
   var x = document.querySelectorAll('.nav-item .material-icons'); 
-  for(var i = 0; i < x.length; i++){ 
+  for(var i = 0; i < x.length; i++){
     mdc.ripple.MDCRipple.attachTo(x[i])
     x[i].addEventListener('click', function(event){
-      console.log('click!')
       var item = event.target
       var panel = item.parentElement.nextElementSibling
       var height, itemHasChildren = false;

--- a/src/partials/nav.hbs
+++ b/src/partials/nav.hbs
@@ -1,8 +1,7 @@
 <div class="nav-container" {{#if page.component}} data-component="{{page.component.name}}" data-version="{{page.version}}"{{/if}}>
   <aside class="nav-container">
     <div class="panels">
-{{> nav-menu}}
-{{!-- {{> nav-explore}} --}}
+      {{> nav-menu}}
     </div>
   </aside>
 </div>

--- a/src/scss/_variables.scss
+++ b/src/scss/_variables.scss
@@ -12,3 +12,5 @@ $mdc-theme-on-error: white;
 $mdc-theme-surface: white;
 $mdc-theme-on-surface: white; 
 $mdc-theme-background: white;
+
+$light-gray: #aaa;

--- a/src/scss/nav.scss
+++ b/src/scss/nav.scss
@@ -38,20 +38,24 @@ div.nav-container {
     color: black; 
     vertical-align: middle;
     padding-top: 0.2rem; 
-    padding-bottom: 0.2rem; 
+    padding-bottom: 0.2rem;
+
+    &:hover {
+      color: $mdc-theme-secondary;
+    }
 
     a{
       text-decoration: none; 
-      color: black; 
+      color: black;
+
+      &:hover {
+        @extend .nav-item:hover;
+      }
     }
 
 
     & .is-current-page {
       color: $mdc-theme-secondary; 
-    }
-
-    &:hover {
-      background-color: #EEEEEE;
     }
   }
 
@@ -72,15 +76,15 @@ div.nav-container {
 .nav-trees {
   max-width: 100%;
   margin: 0; 
-  margin-right: 2rem; 
+  margin-right: 2rem;
+  padding: 0.2rem 0;
 }
 
 // version select 
 .version-box {
   margin: 0; 
   float: right; 
-  display: inline-block; 
-  margin-top: 4px;
+  display: inline-block;
 
   span {
     color: $light-gray;
@@ -107,14 +111,14 @@ div.nav-container {
 
 
 .select-version {
-	display: block;
-	font-size: 0.6em;
-	color: $light-gray;
-	padding: 0.5vh 0.1vw;
-	box-sizing: border-box;
-	margin: 0;
-	border: 1px solid $light-gray;
-	border-radius: .5em;
+  display: block;
+  font-size: 0.6em;
+  color: $light-gray;
+  padding: 0.5vh 0.1vw;
+  box-sizing: border-box;
+  margin: 0;
+  border: 1px solid $light-gray;
+  border-radius: .5em;
   -moz-appearance: none;
 }
 

--- a/src/scss/nav.scss
+++ b/src/scss/nav.scss
@@ -80,13 +80,24 @@ div.nav-container {
   margin: 0; 
   float: right; 
   display: inline-block; 
-  margin-top: 4px; 
+  margin-top: 4px;
 
   span {
-    color: #aaa;
+    color: $light-gray;
     padding-left: 1.2em; 
     padding-top: -0.1em; 
     font-size: 0.5vw; 
+  }
+
+  .single-version {
+    background-color: $mdc-theme-background;
+    border-color: $mdc-theme-background;
+    color: $light-gray;
+  }
+
+  .single-version:hover {
+    border-color: $mdc-theme-background;
+    color: $light-gray;
   }
 
   &:hover span {
@@ -98,11 +109,11 @@ div.nav-container {
 .select-version {
 	display: block;
 	font-size: 0.6em;
-	color: #aaa;
+	color: $light-gray;
 	padding: 0.5vh 0.1vw;
 	box-sizing: border-box;
 	margin: 0;
-	border: 1px solid #aaa;
+	border: 1px solid $light-gray;
 	border-radius: .5em;
   -moz-appearance: none;
 }
@@ -117,12 +128,9 @@ div.nav-container {
 }
 
 .select-version:focus {
-	border-color: #aaa;
-	box-shadow: #aaa;
-	box-shadow: 0 0 0 3px -moz-mac-focusring;
   color: $mdc-theme-secondary;
   border-color: $mdc-theme-secondary;
-	outline: none;
+  outline: none;
 }
 
 .select-version option {


### PR DESCRIPTION
**Description:**


This PR modifies the sidebar so that single-version content does not get a version selection button. Instead the single version is displayed. It also modifies the `.gitignore` file so that Webstorm IDE related files and Github Pages build files do not get committed.

On a technical level, a `select` DOM element with a single `option` child element is still used to render the version. However, the `select` element is disabled and styled so that it appears to be plain text. I chose to do this so that the version numbers would line up correctly at various resolutions.

**Work remaining:**

- [x] Fix version background color when side-nav row is highlighted. 

**Screenshots:**


![Screen Shot 2020-02-06 at 9 38 17 AM](https://user-images.githubusercontent.com/1717845/73948114-8e849700-48c6-11ea-97cb-671ccbcb1e03.png)


![Screen Shot 2020-02-06 at 10 52 01 AM](https://user-images.githubusercontent.com/1717845/73954011-38682180-48cf-11ea-9e2f-19c345b031e7.png)

