### PR TITLE
Make navigation responsive.

### DIFF
--- a/src/js/00-nav.js
+++ b/src/js/00-nav.js
@@ -47,29 +47,13 @@
     x[i].addEventListener('click', function(event){
       var item = event.target
       var panel = item.parentElement.nextElementSibling
-      var height, itemHasChildren = false;
-      if(panel){
-        itemHasChildren = panel.classList.contains('nav-children-panel')
-      }
-      if(itemHasChildren){
-        height = panel.scrollHeight
-        var childrenPanels = panel.querySelectorAll('.nav-children-panel')
-        for(var j=0; j < childrenPanels.length; j++){
-            height = height + childrenPanels[j].scrollHeight
-        }
-      }
       if(item.classList.contains('expanded')){
         item.classList.remove('expanded')
-        if(itemHasChildren){
-          panel.style.maxHeight = null
-        }
+        panel.classList.add('hide')
       } else{
         item.classList.add('expanded')
-        if(itemHasChildren){
-          panel.style.maxHeight = height + 'px'
-        }
+        panel.classList.remove('hide')
       }
-
     })
   }
 
@@ -78,7 +62,11 @@
   mdc.iconButton.MDCIconButtonToggle.attachTo(navToggle)
   navToggle.addEventListener('click', function(){
     var navContainer = document.querySelector('div.nav-container')
-    var aside = document.querySelector('div.nav-container aside')
+    if(navContainer.classList.contains('hide')){
+      navContainer.classList.remove('hide')
+    } else{
+      navContainer.classList.add('hide')
+    }
   })
 
 })()

--- a/src/js/04-mobile-navbar.js
+++ b/src/js/04-mobile-navbar.js
@@ -1,4 +1,11 @@
 document.addEventListener('DOMContentLoaded', function () {
+  // Hide navbar on mobile
+  if (window.innerWidth <= 1024) {
+    var navContainer = document.querySelector('div.nav-container')
+    navContainer.classList.add('hide')
+  }
+
+  // Add event listeners to hamburger icons
   var navbarToggles = Array.prototype.slice.call(document.querySelectorAll('.navbar-burger'), 0)
   if (navbarToggles.length === 0) return
   navbarToggles.forEach(function (el) {
@@ -10,3 +17,14 @@ document.addEventListener('DOMContentLoaded', function () {
     })
   })
 })
+
+
+// Expand navbar if window is resized from mobile to desktop
+window.addEventListener('resize', function () {
+  var navContainer = document.querySelector('div.nav-container')
+  if (window.innerWidth > 1024) {
+    if (navContainer.classList.contains('hide')) {
+      navContainer.classList.remove('hide')
+    }
+  }
+});

--- a/src/layouts/default.hbs
+++ b/src/layouts/default.hbs
@@ -1,11 +1,11 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
-{{> head defaultPageTitle='Untitled'}}
+    {{> head defaultPageTitle='Untitled'}}
   </head>
   <body class="article">
-{{> header}}
-{{> body}}
-{{> footer}}
+    {{> header}}
+    {{> body}}
+    {{> footer}}
   </body>
 </html>

--- a/src/partials/nav-menu.hbs
+++ b/src/partials/nav-menu.hbs
@@ -20,7 +20,7 @@
               {{{./title}}}
             </a>
           </div>
-          <div class="nav-children-panel">
+          <div class="nav-children-panel hide">
             {{> nav-tree navigation=./navigation }}
           </div>
         </div>

--- a/src/partials/nav-tree.hbs
+++ b/src/partials/nav-tree.hbs
@@ -36,7 +36,7 @@
       {{#if ./root}}
           {{> nav-tree navigation=./items}}
       {{else}}
-        <div class="nav-children-panel">
+        <div class="nav-children-panel hide">
           {{> nav-tree navigation=./items}}
         </div>
       {{/if}}

--- a/src/scss/body.scss
+++ b/src/scss/body.scss
@@ -1,3 +1,8 @@
+.body {
+  position: absolute;
+  top: var(--navbar-height);
+}
+
 @media screen and (min-width: 1024px) {
   .body {
     display: flex;

--- a/src/scss/nav.scss
+++ b/src/scss/nav.scss
@@ -18,8 +18,8 @@ div.nav-container {
 
   .material-icons.show-more {
     color: black; 
-    font-size: 1.2em; 
-    min-width: 1rem; 
+    font-size: 1.0rem;
+    min-width: 1.0rem;
     transition: all $expand-animation-time ease-in-out; 
     
     &:hover {
@@ -33,12 +33,20 @@ div.nav-container {
   }
 
   .nav-item {
-    font-size: 0.75vw; 
+    font-size: 0.75rem;
     max-width: 16rem; 
     color: black; 
     vertical-align: middle;
     padding-top: 0.2rem; 
     padding-bottom: 0.2rem;
+
+    /* Setup word wrapping. overflow-wrap and word-wrap are aliases but some
+       browsers support one and not the other. Similarly, webkit only respects
+       break-word for word-break. */
+    hyphens: auto;
+    overflow-wrap: break-word;
+    word-break: break-word;
+    word-wrap: break-word;
 
     &:hover {
       color: $mdc-theme-secondary;
@@ -67,9 +75,10 @@ div.nav-container {
 }
 
 .nav-children-panel {
-  padding-left: 0.5rem; 
-  max-height: 0;
-  overflow: hidden; 
+  display: block;
+  padding-left: 0.5rem;
+  overflow: auto;
+  min-width: 5rem;
   transition: max-height $expand-animation-time ease-out;
 }
 
@@ -88,9 +97,9 @@ div.nav-container {
 
   span {
     color: $light-gray;
-    padding-left: 1.2em; 
-    padding-top: -0.1em; 
-    font-size: 0.5vw; 
+    padding-left: 1.2rem;
+    padding-top: -0.1rem;
+    font-size: 0.75rem;
   }
 
   .single-version {
@@ -112,18 +121,18 @@ div.nav-container {
 
 .select-version {
   display: block;
-  font-size: 0.6em;
+  font-size: 0.65rem;
   color: $light-gray;
-  padding: 0.5vh 0.1vw;
+  padding: 0.1rem;
   box-sizing: border-box;
   margin: 0;
   border: 1px solid $light-gray;
-  border-radius: .5em;
+  border-radius: .5rem;
   -moz-appearance: none;
 }
 
 .select-version::-ms-expand {
-	display: none;
+  display: none;
 }
 
 .select-version:hover {
@@ -149,34 +158,17 @@ div.nav-container {
   display: none !important; 
 }
 
-
-// mobile view 
-@media screen and (max-width: 1024px) {
-  div.nav-container{ 
-    max-width: 0; 
-
-    .open { 
-      max-width: $nav-width; 
-    }
-
-    aside { 
-      width: 0; 
-    }
-  }
-}
-
-
 @media screen and (min-width: 1025px){
   div.nav-container {
-    min-width: $nav-width; 
+    min-width: $nav-width;
     aside {
       margin-top: 5rem;
       padding-left: 0.5rem;
       position: fixed;
-      top: 0; 
-      bottom: 0;  
+      top: 0;
+      bottom: 0;
       overflow-y: auto;
-      width: $nav-width; 
+      width: $nav-width;
     }
   }
 }


### PR DESCRIPTION
**Description:**

This PR makes the navigation responsive by doing the following things:

- Defaulting the navigation drawer to closed for mobile devices.
- Having the mobile navigation use 100% of the available width.
- Fixing the hamburger icon on mobile so that pressing it once opens the navigation drawer and pressing it a second time closes the navigation drawer.
- Hiding navigation trees that have not been clicked into, by using `display: none` via a class named `hide`.
    - This also improves accessibility because screen-readers will read content hidden by `over-flow: hidden` but will not read content hidden by `display: none`.
- Basing the padding for the version selection buttons on the user's default font size setting instead of the browser window dimensions.
- Basing font sizes on the user's default font size setting instead of the browser window dimensions.
    - This prevents the links from being significantly too small on mobile.

**Work Remaining:**
- [ ] Make search responsive.

**Screenshots:**

![Screen Shot 2020-02-06 at 2 49 03 PM](https://user-images.githubusercontent.com/1717845/73973050-d8ce3e00-48ef-11ea-889c-971e048a6720.png)

![Screen Shot 2020-02-06 at 2 49 29 PM](https://user-images.githubusercontent.com/1717845/73973084-eaafe100-48ef-11ea-976d-5ad057f05568.png)

